### PR TITLE
Add basic trading feature

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -29,6 +29,7 @@ import StockAnalyzer from "./pages/StockAnalyzer";
 import InvestChatbot from "./pages/InvestChatbot";
 import MarketNewsSummarizer from "./pages/MarketNewsSummarizer";
 import AiRecommendations from "./pages/AiRecommendations";
+import Trade from "./pages/Trade";
 import About from "./pages/About";
 import Contact from "./pages/Contact";
 import Plans from "./pages/Plans";
@@ -124,6 +125,7 @@ function AppContent() {
                   <motion.div className="dropdown-menu" initial={{ opacity: 0, y: -10 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -10 }}>
                     <Link to="/stock-analyzer">Stock Analyzer</Link>
                     <Link to="/invest-chatbot">Invest Chatbot</Link>
+                    <Link to="/trade">Trade</Link>
                     <Link to="/news-summarizer">Market News</Link>
                     <Link to="/ai-recommendations">AI Insights</Link>
                   </motion.div>
@@ -153,6 +155,7 @@ function AppContent() {
         <Route path="/investment-history" element={<ProtectedRoute><InvestmentHistory /></ProtectedRoute>} />
         <Route path="/stock-analyzer" element={<ProtectedRoute><StockAnalyzer /></ProtectedRoute>} />
         <Route path="/invest-chatbot" element={<ProtectedRoute><InvestChatbot /></ProtectedRoute>} />
+        <Route path="/trade" element={<ProtectedRoute><Trade /></ProtectedRoute>} />
         <Route path="/news-summarizer" element={<ProtectedRoute><MarketNewsSummarizer /></ProtectedRoute>} />
         <Route path="/ai-recommendations" element={<ProtectedRoute><AiRecommendations /></ProtectedRoute>} />
         <Route path="/profile" element={<ProtectedRoute><ProfilePage /></ProtectedRoute>} />

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,4 +1,5 @@
-import React, { useContext, useState, useEffect, createContext } from "react";
+import React, { useContext, useState, createContext } from "react";
+import { loginUser, registerUser, logoutUser } from "../services/authService";
 
 const AuthContext = createContext();
 
@@ -9,10 +10,22 @@ export function useAuth() {
 export function AuthProvider({ children }) {
   const [currentUser, setCurrentUser] = useState(null);
 
-  const login = () => setCurrentUser({ name: "DemoUser" });
-  const logout = () => setCurrentUser(null);
+  const login = async (username, password) => {
+    const data = await loginUser(username, password);
+    setCurrentUser({ name: data.username || username });
+  };
 
-  const value = { currentUser, login, logout };
+  const signup = async (credentials) => {
+    const data = await registerUser(credentials);
+    setCurrentUser({ name: data.username || credentials.username });
+  };
+
+  const logout = () => {
+    logoutUser();
+    setCurrentUser(null);
+  };
+
+  const value = { currentUser, login, signup, logout };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }

--- a/src/main/java/com/sns_consultancy/com/interior/app/Controller/TradeController.java
+++ b/src/main/java/com/sns_consultancy/com/interior/app/Controller/TradeController.java
@@ -1,0 +1,31 @@
+package com.sns_consultancy.com.interior.app.Controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/trade")
+public class TradeController {
+
+    @PostMapping("/buy")
+    public ResponseEntity<String> buy(@RequestBody TradeRequest req) {
+        String msg = String.format("Bought %d shares of %s", req.getQuantity(), req.getSymbol());
+        return ResponseEntity.ok(msg);
+    }
+
+    @PostMapping("/sell")
+    public ResponseEntity<String> sell(@RequestBody TradeRequest req) {
+        String msg = String.format("Sold %d shares of %s", req.getQuantity(), req.getSymbol());
+        return ResponseEntity.ok(msg);
+    }
+
+    public static class TradeRequest {
+        private String symbol;
+        private int quantity;
+
+        public String getSymbol() { return symbol; }
+        public void setSymbol(String symbol) { this.symbol = symbol; }
+        public int getQuantity() { return quantity; }
+        public void setQuantity(int quantity) { this.quantity = quantity; }
+    }
+}

--- a/src/pages/CookieConsent.js
+++ b/src/pages/CookieConsent.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 
 export default function CookieConsent() {
   const [visible, setVisible] = useState(false);

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -46,6 +46,10 @@ export default function Dashboard() {
           <h2>🤖 Ask the AI</h2>
           <p>Chat with our smart investment assistant</p>
         </Link>
+        <Link to="/trade" className="card">
+          <h2>💹 Trade</h2>
+          <p>Buy or sell stocks instantly</p>
+        </Link>
       </main>
     </div>
   );

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,20 +1,41 @@
-import React from "react";
+import React, { useState } from "react";
 import { useAuth } from "../context/AuthContext";
 import { useNavigate } from "react-router-dom";
 
 export default function Login() {
   const { login } = useAuth();
   const navigate = useNavigate();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState(null);
 
-  const handleLogin = () => {
-    login();
-    navigate("/chat");
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await login(username, password);
+      navigate("/chat");
+    } catch (err) {
+      console.error(err);
+      setError("Login failed");
+    }
   };
 
   return (
-    <div style={{ textAlign: "center", marginTop: "5rem" }}>
-      <h2>Login Page</h2>
-      <button onClick={handleLogin}>Fake Login</button>
-    </div>
+    <form onSubmit={handleSubmit} style={{ textAlign: "center", marginTop: "5rem" }}>
+      <h2>Login</h2>
+      <input
+        placeholder="Username"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+      />
+      <input
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button type="submit">Login</button>
+      {error && <p>{error}</p>}
+    </form>
   );
 }

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -1,20 +1,41 @@
-import React from "react";
+import React, { useState } from "react";
 import { useAuth } from "../context/AuthContext";
 import { useNavigate } from "react-router-dom";
 
 export default function Signup() {
-  const { login } = useAuth();
+  const { signup } = useAuth();
   const navigate = useNavigate();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState(null);
 
-  const handleSignup = () => {
-    login();
-    navigate("/chat");
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await signup({ username, password });
+      navigate("/chat");
+    } catch (err) {
+      console.error(err);
+      setError("Signup failed");
+    }
   };
 
   return (
-    <div style={{ textAlign: "center", marginTop: "5rem" }}>
-      <h2>Signup Page</h2>
-      <button onClick={handleSignup}>Fake Sign Up</button>
-    </div>
+    <form onSubmit={handleSubmit} style={{ textAlign: "center", marginTop: "5rem" }}>
+      <h2>Sign Up</h2>
+      <input
+        placeholder="Username"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+      />
+      <input
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button type="submit">Sign Up</button>
+      {error && <p>{error}</p>}
+    </form>
   );
 }

--- a/src/pages/Trade.jsx
+++ b/src/pages/Trade.jsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import { buyStock, sellStock } from '../services/tradeService';
+
+export default function Trade() {
+  const [symbol, setSymbol] = useState('');
+  const [quantity, setQuantity] = useState('');
+  const [result, setResult] = useState('');
+
+  const handleBuy = async () => {
+    try {
+      const res = await buyStock(symbol, Number(quantity));
+      setResult(res.message || 'Trade executed');
+    } catch (err) {
+      setResult('Trade failed');
+    }
+  };
+
+  const handleSell = async () => {
+    try {
+      const res = await sellStock(symbol, Number(quantity));
+      setResult(res.message || 'Trade executed');
+    } catch (err) {
+      setResult('Trade failed');
+    }
+  };
+
+  return (
+    <div style={{ maxWidth: '400px', margin: '2rem auto' }}>
+      <h2>Trade Stocks</h2>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <input
+          placeholder="Symbol"
+          value={symbol}
+          onChange={e => setSymbol(e.target.value)}
+        />
+        <input
+          type="number"
+          placeholder="Quantity"
+          value={quantity}
+          onChange={e => setQuantity(e.target.value)}
+        />
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <button onClick={handleBuy}>Buy</button>
+          <button onClick={handleSell}>Sell</button>
+        </div>
+        {result && <p>{result}</p>}
+      </div>
+    </div>
+  );
+}

--- a/src/services/tradeService.js
+++ b/src/services/tradeService.js
@@ -1,0 +1,19 @@
+const API_URL = process.env.REACT_APP_API_URL;
+
+async function request(path, payload) {
+  const res = await fetch(`${API_URL}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (!res.ok) throw new Error('Request failed');
+  return res.json();
+}
+
+export function buyStock(symbol, quantity) {
+  return request('/api/trade/buy', { symbol, quantity });
+}
+
+export function sellStock(symbol, quantity) {
+  return request('/api/trade/sell', { symbol, quantity });
+}


### PR DESCRIPTION
## Summary
- add simple trade service and page
- enable login and signup forms with auth service
- integrate trade link into dashboard and routing
- add TradeController for placeholder buy/sell endpoints

## Testing
- `npm test`
- `mvn -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_688a539c2030832d97864836d4b5d3d2